### PR TITLE
Correct spelling of function name "broadcat!"

### DIFF
--- a/indexing_part1_introduction.ipynb
+++ b/indexing_part1_introduction.ipynb
@@ -26,7 +26,7 @@
     "* `getindex`, a.k.a. `x[...]`\n",
     "* `setindex!`, a.k.a. `x[...] =`\n",
     "* `broadcast`, a.k.a. `fun.(x)`\n",
-    "* `broadcat!`, a.k.a. `x .= ...`\n",
+    "* `broadcast!`, a.k.a. `x .= ...`\n",
     "* `getproperty`, a.k.a. `x.field` and `x.field .= ...`\n",
     "* `setproperty`, a.k.a. `x.field = ...`\n",
     "\n",


### PR DESCRIPTION
Replace "broadcat!" with "broadcast!".